### PR TITLE
 Add GET /products/{id} endpoint to products microservice

### DIFF
--- a/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/controller/ProductController.java
+++ b/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/controller/ProductController.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 
-@Tag(name = "CRUD REST APIs for Products in Iecommerce", description = "CRUD REST APIs in Iecommerce to CREATE, UPDATE, FETCH AND DELETE product details")
+@Tag(name = "Product API", description = "REST API endpoints in Iecommerce to CREATE, UPDATE, FETCH, and DELETE product details")
 @RestController
 @RequestMapping(path = "api/v1/products", produces = { MediaType.APPLICATION_JSON_VALUE })
 @AllArgsConstructor
@@ -31,7 +31,7 @@ public class ProductController {
 
 	private IProductService service;
 
-	@Operation(summary = "Fetch Products page REST API", description = "REST API to fetch a products page with sort option")
+	@Operation(summary = "Fetch Products paged", description = "Fetch a products page with sort and filtering options")
 	@ApiResponses({ @ApiResponse(responseCode = "200", description = "HTTP Status OK"),
 			@ApiResponse(responseCode = "400", description = "HTTP Status Internal Bad Request", content = @Content(schema = @Schema(implementation = StandardErrorDto.class))),
 			@ApiResponse(responseCode = "500", description = "HTTP Status Internal Server Error", content = @Content(schema = @Schema(implementation = StandardErrorDto.class))) })
@@ -44,6 +44,11 @@ public class ProductController {
 
 	}
 
+	@Operation(summary = "Fetch product by ID", description = "Fetch a product from the system using its ID")
+	@ApiResponses({ @ApiResponse(responseCode = "200", description = "HTTP Status OK"),
+			@ApiResponse(responseCode = "400", description = "HTTP Status Internal Bad Request", content = @Content(schema = @Schema(implementation = StandardErrorDto.class))),
+			@ApiResponse(responseCode = "404", description = "HTTP Status Internal Not Found", content = @Content(schema = @Schema(implementation = StandardErrorDto.class))),
+			@ApiResponse(responseCode = "500", description = "HTTP Status Internal Server Error", content = @Content(schema = @Schema(implementation = StandardErrorDto.class))) })
 	@GetMapping(value = "/{id}")
 	public ResponseEntity<ProductDto> findById(@PathVariable Long id) {
 		ProductDto dto = service.findById(id);

--- a/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/controller/ProductController.java
+++ b/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/controller/ProductController.java
@@ -6,6 +6,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,22 +27,27 @@ import lombok.AllArgsConstructor;
 @RestController
 @RequestMapping(path = "api/v1/products", produces = { MediaType.APPLICATION_JSON_VALUE })
 @AllArgsConstructor
-public class ProductController {	
-	
+public class ProductController {
+
 	private IProductService service;
-	
+
 	@Operation(summary = "Fetch Products page REST API", description = "REST API to fetch a products page with sort option")
-	@ApiResponses({ 
-		    @ApiResponse(responseCode = "200", description = "HTTP Status OK"),
-		    @ApiResponse(responseCode = "400", description = "HTTP Status Internal Bad Request", content = @Content(schema = @Schema(implementation = StandardErrorDto.class))),
+	@ApiResponses({ @ApiResponse(responseCode = "200", description = "HTTP Status OK"),
+			@ApiResponse(responseCode = "400", description = "HTTP Status Internal Bad Request", content = @Content(schema = @Schema(implementation = StandardErrorDto.class))),
 			@ApiResponse(responseCode = "500", description = "HTTP Status Internal Server Error", content = @Content(schema = @Schema(implementation = StandardErrorDto.class))) })
 	@GetMapping
 	public ResponseEntity<Page<ProductDto>> findAll(@ModelAttribute ProductFilterDto filter, Pageable pageable) {
-		
+
 		Page<ProductDto> products = service.findAll(filter, pageable);
-		
+
 		return ResponseEntity.ok(products);
-		
+
+	}
+
+	@GetMapping(value = "/{id}")
+	public ResponseEntity<ProductDto> findById(@PathVariable Long id) {
+		ProductDto dto = service.findById(id);
+		return ResponseEntity.ok(dto);
 	}
 
 }

--- a/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/controller/handler/ControllerExceptionHandler.java
+++ b/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/controller/handler/ControllerExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.icaro.freitas.iecommerce_products.dto.StandardErrorDto;
+import com.icaro.freitas.iecommerce_products.exception.ResourceNotFoundException;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -22,6 +23,18 @@ public class ControllerExceptionHandler {
             HttpStatus.BAD_REQUEST.value(),
             "Bad Request",
             "Invalid property given: " + ex.getPropertyName(),
+            request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(err);
+    }
+	
+	@ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<StandardErrorDto> resourceNotFound(ResourceNotFoundException ex, HttpServletRequest request) {
+        StandardErrorDto err = new StandardErrorDto(
+            Instant.now(),
+            HttpStatus.NOT_FOUND.value(),
+            "Not Found",
+            "Resource not found",
             request.getRequestURI()
         );
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(err);

--- a/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/controller/handler/ControllerExceptionHandler.java
+++ b/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/controller/handler/ControllerExceptionHandler.java
@@ -18,26 +18,28 @@ public class ControllerExceptionHandler {
 	
 	@ExceptionHandler(PropertyReferenceException.class)
     public ResponseEntity<StandardErrorDto> propertyReference(PropertyReferenceException ex, HttpServletRequest request) {
+		final HttpStatus status = HttpStatus.BAD_REQUEST;
         StandardErrorDto err = new StandardErrorDto(
             Instant.now(),
-            HttpStatus.BAD_REQUEST.value(),
+            status.value(),
             "Bad Request",
             "Invalid property given: " + ex.getPropertyName(),
             request.getRequestURI()
         );
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(err);
+        return ResponseEntity.status(status).body(err);
     }
 	
 	@ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<StandardErrorDto> resourceNotFound(ResourceNotFoundException ex, HttpServletRequest request) {
+		final HttpStatus status = HttpStatus.NOT_FOUND;
         StandardErrorDto err = new StandardErrorDto(
             Instant.now(),
-            HttpStatus.NOT_FOUND.value(),
+            status.value(),
             "Not Found",
             "Resource not found",
             request.getRequestURI()
         );
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(err);
+        return ResponseEntity.status(status).body(err);
     }
 
 }

--- a/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/exception/ResourceNotFoundException.java
+++ b/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/exception/ResourceNotFoundException.java
@@ -1,0 +1,11 @@
+package com.icaro.freitas.iecommerce_products.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public ResourceNotFoundException(String msg) {
+		super(msg);
+	}
+
+}

--- a/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/mapper/ProductMapper.java
+++ b/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/mapper/ProductMapper.java
@@ -1,30 +1,24 @@
 package com.icaro.freitas.iecommerce_products.mapper;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.icaro.freitas.iecommerce_products.dto.CategoryDto;
 import com.icaro.freitas.iecommerce_products.dto.ProductDto;
+import com.icaro.freitas.iecommerce_products.entity.Category;
 import com.icaro.freitas.iecommerce_products.entity.Product;
 
 public class ProductMapper {
-	
-	public static ProductDto toDto(Product product) {
-		
-		List<CategoryDto> categoryDtos = product.getCategories().stream()
-		        .map(c -> CategoryMapper.toDto(c))
-		        .toList();
 
-		    return new ProductDto(
-		        product.getId(),
-		        product.getName(),
-		        product.getDescription(),
-		        product.getPrice(),
-		        product.getQuantity(),
-		        product.getImageUrl(),
-		        product.getSlug(),
-		        product.getActive(),
-		        categoryDtos
-		    );
+	public static ProductDto toDto(Product product) {
+
+		Set<Category> categories = product.getCategories();
+
+		List<CategoryDto> categoryDtos = categories.stream().map(CategoryMapper::toDto).collect(Collectors.toList());
+
+		return new ProductDto(product.getId(), product.getName(), product.getDescription(), product.getPrice(),
+				product.getQuantity(), product.getImageUrl(), product.getSlug(), product.getActive(), categoryDtos);
 	}
 
 }

--- a/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/service/IProductService.java
+++ b/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/service/IProductService.java
@@ -9,5 +9,7 @@ import com.icaro.freitas.iecommerce_products.dto.ProductFilterDto;
 public interface IProductService {
 	
 	Page<ProductDto> findAll(ProductFilterDto filter,Pageable pageable);
+	
+	ProductDto findById(Long id);
 
 }

--- a/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/service/impl/ProductServiceImpl.java
+++ b/iecommerce-products/src/main/java/com/icaro/freitas/iecommerce_products/service/impl/ProductServiceImpl.java
@@ -6,9 +6,11 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+
 import com.icaro.freitas.iecommerce_products.dto.ProductDto;
 import com.icaro.freitas.iecommerce_products.dto.ProductFilterDto;
 import com.icaro.freitas.iecommerce_products.entity.Product;
+import com.icaro.freitas.iecommerce_products.exception.ResourceNotFoundException;
 import com.icaro.freitas.iecommerce_products.mapper.ProductMapper;
 import com.icaro.freitas.iecommerce_products.repository.ProductRepository;
 import com.icaro.freitas.iecommerce_products.service.IProductService;
@@ -36,6 +38,14 @@ public class ProductServiceImpl implements IProductService {
 
 		Page<Product> page = repository.findAll(spec, pageable);
 		return page.map(ProductMapper::toDto);
+	}
+
+	@Transactional(readOnly = true)
+	@Override
+	public ProductDto findById(Long id) {
+		Product product = repository.findById(id)
+				.orElseThrow(() -> new ResourceNotFoundException("Entity not found"));
+		return ProductMapper.toDto(product);
 	}
 
 }

--- a/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/controller/ProductControllerTests.java
+++ b/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/controller/ProductControllerTests.java
@@ -25,35 +25,48 @@ import org.springframework.test.web.servlet.ResultActions;
 import com.icaro.freitas.iecommerce_products.dto.ProductDto;
 import com.icaro.freitas.iecommerce_products.dto.ProductFilterDto;
 import com.icaro.freitas.iecommerce_products.entity.Product;
+import com.icaro.freitas.iecommerce_products.exception.ResourceNotFoundException;
 import com.icaro.freitas.iecommerce_products.mapper.ProductMapper;
 import com.icaro.freitas.iecommerce_products.service.IProductService;
 import com.icaro.freitas.iecommerce_products.testutil.ProductFactory;
 
-
 @WebMvcTest(value = ProductController.class, excludeAutoConfiguration = { SecurityAutoConfiguration.class })
 public class ProductControllerTests {
-	
+
 	@Autowired
 	private MockMvc mockMvc;
 
 	@MockitoBean
-	private IProductService service;	
-	
-	private Page<ProductDto> productDtoPage;	
+	private IProductService service;
+
+	private Page<ProductDto> productDtoPage;
+
+	private Long existingProductId;
+	private Long nonExistingProductId;
+	private Product product;
+	private ProductDto productDto;
 
 	@BeforeEach
 	void setUp() throws Exception {
-		
-		List<Product> productList = ProductFactory.createProductList();
-		
-		List<ProductDto> productDtoList = productList.stream().map(ProductMapper::toDto).toList();
-		
-		productDtoPage = new PageImpl<>(productDtoList); 		
 
-		when(service.findAll(any(ProductFilterDto.class),any(Pageable.class))).thenReturn(productDtoPage);
-		
+		List<Product> productList = ProductFactory.createProductList();
+
+		List<ProductDto> productDtoList = productList.stream().map(ProductMapper::toDto).toList();
+
+		productDtoPage = new PageImpl<>(productDtoList);
+
+		existingProductId = 1L;
+		nonExistingProductId = 2L;
+		product = ProductFactory.createProduct();
+		productDto = ProductMapper.toDto(product);
+
+		when(service.findAll(any(ProductFilterDto.class), any(Pageable.class))).thenReturn(productDtoPage);
+
+		when(service.findById(existingProductId)).thenReturn(productDto);
+		when(service.findById(nonExistingProductId)).thenThrow(ResourceNotFoundException.class);
+
 	}
-	
+
 	@Test
 	public void findAllShouldReturnProductDtoPage() throws Exception {
 
@@ -73,6 +86,34 @@ public class ProductControllerTests {
 		result.andExpect(jsonPath("$.content[0].price").value(firstProductExpectedPrice));
 		result.andExpect(jsonPath("$.content[0].imageUrl").value(firstProductExpectedImageUrl));
 		result.andExpect(jsonPath("$.content[0].categories[0].name").value(firstProductExpectedFirstCategoryName));
-	}	
+	}
+
+	@Test
+	public void findByIdShouldReturnProductDtoWhenIdExists() throws Exception {
+
+		final String firstProductExpectedName = "Notebook asus vivobook";
+		final BigDecimal firstProductExpectedPrice = new BigDecimal("2867.0");
+		final String firstProductExpectedImageUrl = "img/notebook-asus-vivobook";
+		final String firstProductExpectedFirstCategoryName = "Eletrônicos";
+
+		ResultActions result = mockMvc
+				.perform(get("/api/v1/products/{id}", existingProductId).accept(MediaType.APPLICATION_JSON));
+
+		result.andExpect(status().isOk());
+		result.andExpect(jsonPath("$.id").value(existingProductId));
+		result.andExpect(jsonPath("$.name").value(firstProductExpectedName));
+		result.andExpect(jsonPath("$.price").value(firstProductExpectedPrice));
+		result.andExpect(jsonPath("$.imageUrl").value(firstProductExpectedImageUrl));
+		result.andExpect(jsonPath("$.categories[0].name").value(firstProductExpectedFirstCategoryName));
+	}
+	
+	@Test
+	public void findByIdShouldReturnNotFoundWhenIdDoesNotExist() throws Exception {
+
+		ResultActions result = mockMvc.perform(get("/api/v1/products/{id}", nonExistingProductId).accept(MediaType.APPLICATION_JSON));
+
+		result.andExpect(status().isNotFound());
+
+	}
 
 }

--- a/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/controller/it/ProductControllerIT.java
+++ b/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/controller/it/ProductControllerIT.java
@@ -26,6 +26,9 @@ public class ProductControllerIT {
 
 	@Autowired
 	private MockMvc mockMvc;
+	
+	private Long existingProductId = 1L;
+	private Long nonExistingProductId = 99L;
 
 	@Test
 	public void findAllShouldReturnProductDtoPage() throws Exception {
@@ -120,6 +123,34 @@ public class ProductControllerIT {
 		result.andExpect(jsonPath("$.content.length()").value(expectedSize));
 		result.andExpect(jsonPath("$.content[0].id").value(expectedId));
 		result.andExpect(jsonPath("$.content[0].name").value(expectedName));
+	}
+	
+	@Test
+	public void findByIdShouldReturnProductDtoWhenIdExists() throws Exception {
+
+		final String firstProductExpectedName = "Notebook asus vivobook";
+		final BigDecimal firstProductExpectedPrice = new BigDecimal("2867.0");
+		final String firstProductExpectedImageUrl = "img/notebook-asus-vivobook";
+		final String firstProductExpectedFirstCategoryName = "Eletrônicos";
+
+		ResultActions result = mockMvc
+				.perform(get("/api/v1/products/{id}", existingProductId).accept(MediaType.APPLICATION_JSON));
+
+		result.andExpect(status().isOk());
+		result.andExpect(jsonPath("$.id").value(existingProductId));
+		result.andExpect(jsonPath("$.name").value(firstProductExpectedName));
+		result.andExpect(jsonPath("$.price").value(firstProductExpectedPrice));
+		result.andExpect(jsonPath("$.imageUrl").value(firstProductExpectedImageUrl));
+		result.andExpect(jsonPath("$.categories[0].name").value(firstProductExpectedFirstCategoryName));
+	}
+	
+	@Test
+	public void findByIdShouldReturnNotFoundWhenIdDoesNotExist() throws Exception {
+
+		ResultActions result = mockMvc.perform(get("/api/v1/products/{id}", nonExistingProductId).accept(MediaType.APPLICATION_JSON));
+
+		result.andExpect(status().isNotFound());
+
 	}
 
 }

--- a/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/repository/ProductRepositoryTests.java
+++ b/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/repository/ProductRepositoryTests.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -89,6 +90,26 @@ public class ProductRepositoryTests {
 
 		Assertions.assertFalse(result.isEmpty());
 		Assertions.assertEquals(expectedName, firstProduct.getName());
+	}
+
+	@Test
+	public void findByIdShouldReturnProductDtoWhenIdExists() {
+		Long existingProductId = 1L;
+		Optional<Product> result = repository.findById(existingProductId);
+
+		Product product = result.get();
+
+		Assertions.assertNotNull(existingProductId);
+		Assertions.assertEquals(product.getId(), existingProductId);
+	}
+
+	@Test
+	public void findByIdShouldReturnEmptyOptionalResultWhenIdDoesNotExist() {
+		Long nonExistingProductId = 99L;
+		Optional<Product> result = repository.findById(nonExistingProductId);
+
+		Assertions.assertTrue(result.isEmpty());
+
 	}
 
 }

--- a/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/service/CategoryServiceImplTests.java
+++ b/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/service/CategoryServiceImplTests.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.icaro.freitas.iecommerce_products.dto.CategoryDto;
 import com.icaro.freitas.iecommerce_products.entity.Category;
@@ -22,7 +22,7 @@ import com.icaro.freitas.iecommerce_products.repository.CategoryRepository;
 import com.icaro.freitas.iecommerce_products.service.impl.CategoryServiceImpl;
 import com.icaro.freitas.iecommerce_products.testutil.CategoryFactory;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith(SpringExtension.class)
 public class CategoryServiceImplTests {
 
 	@Mock

--- a/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/service/ProductServiceImplTests.java
+++ b/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/service/ProductServiceImplTests.java
@@ -1,6 +1,7 @@
 package com.icaro.freitas.iecommerce_products.service;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,22 +10,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.icaro.freitas.iecommerce_products.dto.ProductDto;
 import com.icaro.freitas.iecommerce_products.dto.ProductFilterDto;
 import com.icaro.freitas.iecommerce_products.entity.Category;
 import com.icaro.freitas.iecommerce_products.entity.Product;
+import com.icaro.freitas.iecommerce_products.exception.ResourceNotFoundException;
 import com.icaro.freitas.iecommerce_products.repository.ProductRepository;
 import com.icaro.freitas.iecommerce_products.service.impl.ProductServiceImpl;
 import com.icaro.freitas.iecommerce_products.testutil.ProductFactory;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith(SpringExtension.class)
 public class ProductServiceImplTests {
 
 	@Mock
@@ -32,18 +34,31 @@ public class ProductServiceImplTests {
 
 	@InjectMocks
 	private ProductServiceImpl service;
-
+	
+	
 	private List<Product> list;
 	private Page<Product> page;
+	private Long existingProductId;
+	private Long nonExistingProductId;
+	private Product product;	
 
 	@SuppressWarnings("unchecked")
 	@BeforeEach
 	private void setUp() throws Exception {
+		existingProductId = 1L;
+		nonExistingProductId = 2L;
+		product= ProductFactory.createProduct();
 
 		list = ProductFactory.createProductList();
 		page = new PageImpl<>(list);
+
+		
 		Mockito.when(repository.findAll((Specification<Product>) Mockito.any(Specification.class),
-				Mockito.any(Pageable.class))).thenReturn(page);
+				Mockito.any(Pageable.class))).thenReturn(page);				
+		
+		Mockito.when(repository.findById(existingProductId)).thenReturn(Optional.of(product));
+		Mockito.when(repository.findById(nonExistingProductId)).thenReturn(Optional.empty());
+		
 	}
 
 	@Test
@@ -63,6 +78,22 @@ public class ProductServiceImplTests {
 		Assertions.assertEquals(expected.getId(), actual.getId(), "Product ID mismatch");
 		Assertions.assertEquals(expected.getName(), actual.getName(), "Product name mismatch");
 		Assertions.assertTrue(expectedCategoryNames.contains(actualCategoryName));
+	}
+	
+	@Test
+	public void findByIdShouldReturnProductDtoWhenIdExists() {
+		ProductDto result = service.findById(existingProductId);
+
+		Assertions.assertNotNull(existingProductId);
+		Assertions.assertEquals(result.getId(), existingProductId);
+	}
+
+	@Test
+	public void findByIdShouldThrowResourceNotFoundExceptionWhenIdDoesNotExist() {
+
+		Assertions.assertThrows(ResourceNotFoundException.class, () -> {
+			service.findById(nonExistingProductId);
+		});
 	}
 
 }

--- a/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/service/it/CategoryServiceIT.java
+++ b/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/service/it/CategoryServiceIT.java
@@ -17,7 +17,7 @@ import jakarta.transaction.Transactional;
 
 @SpringBootTest
 @Transactional
-public class CategoryServiceImplIT {
+public class CategoryServiceIT {
 	
 	@Autowired
 	private ICategoryService service;

--- a/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/service/it/ProductServiceIT.java
+++ b/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/service/it/ProductServiceIT.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Sort;
 
 import com.icaro.freitas.iecommerce_products.dto.ProductDto;
 import com.icaro.freitas.iecommerce_products.dto.ProductFilterDto;
+import com.icaro.freitas.iecommerce_products.exception.ResourceNotFoundException;
 import com.icaro.freitas.iecommerce_products.service.IProductService;
 
 import jakarta.transaction.Transactional;
@@ -128,6 +129,23 @@ public class ProductServiceIT {
 		Assertions.assertEquals(expectedSize, productList.size());
 		Assertions.assertEquals(expectedId, firstProduct.getId());
 		Assertions.assertEquals(expectedName, firstProduct.getName());
+	}
+	
+	@Test
+	public void findByIdShouldReturnProductDtoWhenIdExists() {
+		Long existingProductId = 1L;
+		ProductDto result = service.findById(existingProductId);
+
+		Assertions.assertNotNull(existingProductId);
+		Assertions.assertEquals(result.getId(), existingProductId);
+	}
+
+	@Test
+	public void findByIdShouldThrowResourceNotFoundExceptionWhenIdDoesNotExist() {
+		Long nonExistingProductId = 99L;
+		Assertions.assertThrows(ResourceNotFoundException.class, () -> {
+			service.findById(nonExistingProductId);
+		});
 	}
 
 }

--- a/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/service/it/ProductServiceIT.java
+++ b/iecommerce-products/src/test/java/com/icaro/freitas/iecommerce_products/service/it/ProductServiceIT.java
@@ -23,7 +23,7 @@ import jakarta.transaction.Transactional;
 
 @SpringBootTest
 @Transactional
-public class ProductServiceImplIT {
+public class ProductServiceIT {
 
 	@Autowired
 	private IProductService service;


### PR DESCRIPTION
- Adds product findById methods to service layer.
- Adds product findById methods to controller layer.
- Adds `products/{id}` endpoint to fetch a product by its id.
- Adds ResourceNotFoundException used when an entity is not found.
- Adds ResourceNotFoundException to exception handler.
- Updates Exception handler, fixes bug.
- Adds unit tests for products service and controller.
- Adds integration tests for products repository, service and controller.
- Renames ProductServiceImplIT and CategoryServiceImplIT to both ProductServiceIT and CategoryServiceIT.
- Adds OpenAPI documentation for `products/{id}` endpoint.
- Updates OpenAPI documentation for better clarity.